### PR TITLE
Errors from running test cases now show on output

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -110,4 +110,4 @@ export function activate(context: vscode.ExtensionContext) {
 	);
 }
 
-export function deactivate() {}
+export function deactivate() { }

--- a/src/libs/getTestOutputChan.ts
+++ b/src/libs/getTestOutputChan.ts
@@ -1,0 +1,2 @@
+import * as vscode from "vscode";
+export const outputChannel = vscode.window.createOutputChannel("Test Cases");


### PR DESCRIPTION
Modified to use only one output channel, clearing before use every time a set of test cases is ran. The behavior of the output channel being spawned and closed after 60 seconds is completely removed. There is always one channel.

Tested with Python with no issues on Linux, but not tested with other languages. 
Sorry for the PR in English, I can read Korean but not proficient enough to talk about these topics in Korean :)